### PR TITLE
Change suffix to suffixes based on new hugo config

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -13,7 +13,7 @@ paginatePath = "page"
 
 [mediaTypes]
   [mediaTypes."text/yaml"]
-    suffix = "yml"
+    suffixes = ["yml"]
 
 [taxonomies]
   category = "categories"


### PR DESCRIPTION
Fix error below when build
```bash
Error: MediaType.Suffix is removed. Before Hugo 0.44 this was used both to set a custom file suffix and as way
to augment the mediatype definition (what you see after the "+", e.g. "image/svg+xml").

This had its limitations. For one, it was only possible with one file extension per MIME type.

Now you can specify multiple file suffixes using "suffixes", but you need to specify the full MIME type
identifier:

[mediaTypes]
[mediaTypes."image/svg+xml"]
suffixes = ["svg", "abc" ]

In most cases, it will be enough to just change:

[mediaTypes]
[mediaTypes."my/custom-mediatype"]
suffix = "txt"

To:

[mediaTypes]
[mediaTypes."my/custom-mediatype"]
suffixes = ["txt"]
```

related bug ticket: https://storjlabs.atlassian.net/browse/WD-15?atlOrigin=eyJpIjoiYTNjMWJiZGMwZDc4NDdjMWFlNDRmM2YzZGMxYmRjYTciLCJwIjoiaiJ9