### PR TITLE
fix env var syntax for branch name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ VERSION := $(shell utils/version)
 export VERSION
 
 BRANCH_NAME ?= $(shell git rev-parse --abbrev-ref HEAD)
-SANITIZED_BRANCH_NAME ?= $(shell echo $BRANCH_NAME | tr : __)
+SANITIZED_BRANCH_NAME ?= $(shell echo $${BRANCH_NAME} | tr : __)
 ifeq (${BRANCH_NAME},master)
 TAG ?= ${VERSION}
 CLUSTER ?= prod


### PR DESCRIPTION
Found BRANCH_NAME env var not echoing out properly in Jenkins logs due to syntax error.