### PR TITLE
Update netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 [build]
 publish = "public"
 command = "hugo --gc --minify"
-baseUrl = "https://storj.io/blog"
+baseUrl = "https://www.storj.io/blog"
 
 [context.production.environment]
 HUGO_VERSION = "0.58.3"


### PR DESCRIPTION
Redirect to www.storj.io/blog instead of storj.io/blog so we don't lose referral information